### PR TITLE
Create common ecs deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# eq-ecs-deploy

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # eq-ecs-deploy
+
+This repository contains a Terraform module that provides a lot of the boilerplate configuration required to deploy a container to an ECS cluster.
+
+Below is an example how to to use this module alongside a container definitions json file.
+
+```
+data "template_file" "schema-validator" {
+  template = "${file("${path.module}/task-definitions/schema-validator.json")}"
+
+  vars {
+    CONTAINER_NAME     = "${var.application_name}"
+    LOG_GROUP          = "${var.env}-${var.application_name}"
+    CONTAINER_REGISTRY = "${var.docker_registry}"
+    CONTAINER_TAG      = "${var.container_tag}"
+  }
+}
+
+module "ecs-service" {
+  source                = "github.com/ONSdigital/eq-ecs-deploy?ref=create-common-ecs-deploy"
+  env                   = "${var.env}"
+  aws_secret_key        = "${var.aws_secret_key}"
+  aws_access_key        = "${var.aws_access_key}"
+  ecs_cluster_name      = "${var.ecs_cluster_name}"
+  aws_alb_listener_arn  = "${var.aws_alb_listener_arn}"
+  dns_zone_name         = "${var.dns_zone_name}"
+  application_name      = "${var.application_name}"
+  container_port        = "5000"
+  container_definitions = "${data.template_file.schema-validator.rendered}"
+}
+```

--- a/aws.tf
+++ b/aws.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "eu-west-1"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_ecs_cluster" "ecs-cluster" {
+  cluster_name = "${var.ecs_cluster_name}"
+}
+
+data "aws_alb_listener" "eq" {
+  arn = "${var.aws_alb_listener_arn}"
+}
+
+data "aws_alb" "eq" {
+  arn = "${data.aws_alb_listener.eq.load_balancer_arn}"
+}
+
+data "aws_route53_zone" "dns_zone" {
+  name = "${var.dns_zone_name}"
+}

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,0 +1,126 @@
+resource "aws_alb_target_group" "target_group" {
+  name     = "${var.env}-${var.application_name}"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${data.aws_alb.eq.vpc_id}"
+
+  health_check = {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 5
+    timeout             = 2
+    path                = "${var.healthcheck_path}"
+  }
+
+  tags {
+    Environment = "${var.env}"
+  }
+}
+
+resource "aws_alb_listener_rule" "listener_rule" {
+  listener_arn = "${var.aws_alb_listener_arn}"
+  priority     = 20
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.target_group.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${aws_route53_record.dns_record.name}"]
+  }
+}
+
+resource "aws_route53_record" "dns_record" {
+  zone_id = "${data.aws_route53_zone.dns_zone.id}"
+  name    = "${var.env}-${var.application_name}.${data.aws_route53_zone.dns_zone.name}"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${data.aws_alb.eq.dns_name}"]
+}
+
+resource "aws_ecs_task_definition" "task_definition" {
+  family                = "${var.env}-${var.application_name}"
+  container_definitions = "${var.container_definitions}"
+}
+
+resource "aws_ecs_service" "service" {
+  depends_on = [
+    "aws_alb_target_group.target_group",
+    "aws_alb_listener_rule.listener_rule",
+  ]
+
+  name            = "${var.env}-${var.application_name}"
+  cluster         = "${data.aws_ecs_cluster.ecs-cluster.id}"
+  task_definition = "${aws_ecs_task_definition.task_definition.family}"
+  desired_count   = "${var.applciation_min_tasks}"
+  iam_role        = "${aws_iam_role.service_iam_role.arn}"
+
+  placement_strategy {
+    type  = "spread"
+    field = "host"
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.target_group.arn}"
+    container_name   = "${var.application_name}"
+    container_port   = "${var.container_port}"
+  }
+
+  lifecycle {
+    ignore_changes = ["placement_strategy"]
+  }
+}
+
+resource "aws_iam_role" "service_iam_role" {
+  name = "${var.env}_iam_for_${var.application_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["ecs.amazonaws.com", "ecs-tasks.amazonaws.com"]
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy_document" "policy_document" {
+  "statement" = {
+    "effect" = "Allow"
+
+    "actions" = [
+      "elasticloadbalancing:*",
+    ]
+
+    "resources" = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "role_policy" {
+  name   = "${var.env}_iam_for_survey_register"
+  role   = "${aws_iam_role.service_iam_role.id}"
+  policy = "${data.aws_iam_policy_document.policy_document.json}"
+}
+
+resource "aws_cloudwatch_log_group" "log_group" {
+  name = "${var.env}-${var.application_name}"
+
+  tags {
+    Environment = "${var.env}"
+  }
+}
+
+output "service_address" {
+  value = "https://${aws_route53_record.dns_record.fqdn}"
+}

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -1,0 +1,48 @@
+variable "env" {
+  description = "The environment name, used to identify your environment"
+}
+
+variable "aws_secret_key" {
+  description = "Amazon Web Service Secret Key"
+}
+
+variable "aws_access_key" {
+  description = "Amazon Web Service Access Key"
+}
+
+variable "ecs_cluster_name" {
+  description = "The name of the ECS cluster"
+}
+
+variable "aws_alb_listener_arn" {
+  description = "The ARN of the ALB"
+}
+
+# DNS
+variable "dns_zone_name" {
+  description = "Amazon Route53 DNS zone name"
+  default     = "eq.ons.digital."
+}
+
+# ECS
+variable "application_name" {
+  description = "The name for the application being deployed"
+}
+
+variable "container_port" {
+  description = "The port that the container exposes"
+}
+
+variable "applciation_min_tasks" {
+  description = "The minimum number of tasks to run"
+  default     = "1"
+}
+
+variable "healthcheck_path" {
+  description = "The path for the Healthcheck path. Should report 200 status"
+  default     = "/"
+}
+
+variable "container_definitions" {
+  description = "The rendered container definitions json. Name must match `application_name`"
+}


### PR DESCRIPTION
This PR contains a common Terraform module to be used to deploy containers to the ECS cluster.
To run this code use the code in the PR https://github.com/ONSdigital/eq-schema-validator-deploy/pull/1