### PR TITLE
Fix container name to be used to load Image

### DIFF
--- a/task-definitions/task.json
+++ b/task-definitions/task.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "${CONTAINER_NAME}",
-    "image": "${CONTAINER_REGISTRY}/eq-schema-validator:${CONTAINER_TAG}",
+    "image": "${CONTAINER_REGISTRY}/${CONTAINER_NAME}:${CONTAINER_TAG}",
     "memoryReservation": 128,
     "essential": true,
     "portMappings": [


### PR DESCRIPTION
The `${CONTAINER_NAME}` variable was not being used for the docker image, as it was hardcoded to `eq-schema-validator`

This PR changes the `task.json` to use the passed in container name