### PR TITLE
Added a service name

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -34,7 +34,7 @@ resource "aws_alb_listener_rule" "listener_rule" {
 
 resource "aws_route53_record" "dns_record" {
   zone_id = "${data.aws_route53_zone.dns_zone.id}"
-  name    = "${var.env}-${var.container_name}.${data.aws_route53_zone.dns_zone.name}"
+  name    = "${var.env}-${var.service_name}.${data.aws_route53_zone.dns_zone.name}"
   type    = "CNAME"
   ttl     = "60"
   records = ["${data.aws_alb.eq.dns_name}"]

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -18,6 +18,10 @@ variable "aws_alb_listener_arn" {
   description = "The ARN of the ALB"
 }
 
+variable "service_name" {
+  description = "The service name used in the URL"
+}
+
 # DNS
 variable "dns_zone_name" {
   description = "Amazon Route53 DNS zone name"


### PR DESCRIPTION
This is used to define how the service will be named in the url

Currently the name of the service in the url is the name of the container.
It would be good if we could override this and use a name of our choice