### PR TITLE
Added Terraform s3 backend for remote state

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -1,3 +1,9 @@
+terraform {
+  backend "s3" {
+    region = "eu-west-1"
+  }
+}
+
 provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"


### PR DESCRIPTION
The PR adds the ability for this module to be run on its own and hold remote state.

To test this you should update one of the modules in `eq-terraform` that uses `eq-ecs-deploy` and append `?ref=add-terraform-remote-state` to the source.

When running terraform apply, it should behave as it did before.