### PR TITLE
Added conditional IAM policy for task_definitions

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -66,3 +66,8 @@ variable "healthcheck_path" {
   description = "The path for the Healthcheck path. Should report 200 status"
   default     = "/"
 }
+
+variable "task_iam_policy_json" {
+  description = "The IAM policy to be used by the container task"
+  default     = ""
+}


### PR DESCRIPTION
Currently this module does not allow tasks to have their own IAM role.

This PR add the ability to conditionally add an IAM policy to a container task.
This is used to allow the running service to authenticate with was services.

To test this, change the `?ref` in `eq-terraform` for one of the modules that uses `eq-ecs-deploy` to this branch `?ref=add-task-iam-policy`
Then validate that the container still deploys as expected.
Then add a policy to the container e.g...
```
task_iam_policy_json = <<EOF
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "",
            "Effect": "Allow",
            "Action": [
              "s3:*"
            ],
            "Resource": "*"
        }
    ]
}
  EOF
```
When viewing the running container the task_definition should display the attached policy