### PR TITLE
Change Route53 Record to Alias instead of CNAME

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -35,9 +35,13 @@ resource "aws_alb_listener_rule" "listener_rule" {
 resource "aws_route53_record" "dns_record" {
   zone_id = "${data.aws_route53_zone.dns_zone.id}"
   name    = "${var.env}-${var.service_name}.${data.aws_route53_zone.dns_zone.name}"
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${data.aws_alb.eq.dns_name}"]
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_alb.eq.dns_name}"
+    zone_id                = "${data.aws_alb.eq.zone_id}"
+    evaluate_target_health = false
+  }
 }
 
 


### PR DESCRIPTION
Checks for resource record sets that can be changed to alias resource record sets to improve performance and save money. An alias resource record set routes DNS queries to an AWS resource (for example, an Elastic Load Balancing load balancer or an Amazon S3 bucket) or to another Route 53 resource record set. When you use alias resource record sets, Route 53 routes your DNS queries to AWS resources free of charge.

### How To Review
After deploying this branch with terraform
Services should still be accessible via the url