### PR TITLE
Increase minimum number of ECS service containers

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -88,7 +88,7 @@ resource "aws_ecs_service" "service" {
   }
 
   lifecycle {
-    ignore_changes = ["placement_strategy"]
+    ignore_changes = ["placement_strategy", "desired_count"]
   }
 }
 

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -59,7 +59,7 @@ variable "container_environment_variables" {
 
 variable "applciation_min_tasks" {
   description = "The minimum number of tasks to run"
-  default     = "1"
+  default     = "2"
 }
 
 variable "healthcheck_path" {


### PR DESCRIPTION
Services with a single container running may experience downtime on a ECS cluster scale down.
By increasing the number to higher than 1 for PreProd and Prod then the service will not experience outage when the cluster scales back

We should also ignore changes for the desired_count. This means that if terraform is run when the environment has scaled then it wont be scaled back down by terraform
lifecycle { ignore_changes = ["desired_count"] }
hashicorp/terraform#4950