### PR TITLE
Introduce variable for overriding health check grace period for ECS service.

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -28,13 +28,13 @@ resource "aws_alb_listener_rule" "listener_rule" {
 
   condition = [
     {
-        field  = "host-header"
-        values = ["${aws_route53_record.dns_record.name}"]
-      },
-      {
-        field  = "path-pattern"
-        values = ["${var.alb_listener_path_pattern}"]
-      },
+      field  = "host-header"
+      values = ["${aws_route53_record.dns_record.name}"]
+    },
+    {
+      field  = "path-pattern"
+      values = ["${var.alb_listener_path_pattern}"]
+    },
   ]
 }
 
@@ -75,11 +75,12 @@ resource "aws_ecs_service" "service" {
     "aws_alb_listener_rule.listener_rule",
   ]
 
-  name            = "${var.env}-${var.service_name}"
-  cluster         = "${data.aws_ecs_cluster.ecs-cluster.id}"
-  task_definition = "${aws_ecs_task_definition.task_definition.family}"
-  desired_count   = "${var.application_min_tasks}"
-  iam_role        = "${aws_iam_role.service_iam_role.arn}"
+  name                              = "${var.env}-${var.service_name}"
+  cluster                           = "${data.aws_ecs_cluster.ecs-cluster.id}"
+  task_definition                   = "${aws_ecs_task_definition.task_definition.family}"
+  desired_count                     = "${var.application_min_tasks}"
+  iam_role                          = "${aws_iam_role.service_iam_role.arn}"
+  health_check_grace_period_seconds = "${var.healthcheck_grace_period_seconds}"
 
   placement_strategy {
     type  = "spread"

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -24,7 +24,7 @@ variable "aws_alb_arn" {
 
 variable "alb_listener_path_pattern" {
   description = "The path pattern to match to route to this service"
-  default = "/*"
+  default     = "/*"
 }
 
 variable "service_name" {
@@ -99,4 +99,9 @@ variable "high_cpu_threshold" {
 variable "low_cpu_threshold" {
   description = "The Average CPU usage at which to trigger the low CPU alarm"
   default     = "20"
+}
+
+variable "healthcheck_grace_period_seconds" {
+  description = "Number of seconds to wait before first health check."
+  default     = 5
 }


### PR DESCRIPTION
### Description

This PR introduces a new variable to allow module instances to override health check configuration.

Sensible defaults have been provided so that module instances are not required to specify these values.

This change is required to support a change to the eq-terraform project, where the author, author-api and publisher have been converted to be eq-ecs-deploy module instances. The author application, in particular, needs a longer time to become "healthy" since static assets are compiled at runtime, which can take a bit of time.

An [option to set the health check grace period on ecs_service](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#health_check_grace_period_seconds), has been used which requires aws provider version >= 1.7.

### How to review

Ensure that changes look sensible.
Should be able to provision environment as before using eq-terraform.