### PR TITLE
Reintroduce dependency on aws_lb_listener

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -18,11 +18,6 @@ data "aws_ecs_cluster" "ecs-cluster" {
   cluster_name = "${var.ecs_cluster_name}"
 }
 
-data "aws_lb_listener" "eq" {
-  load_balancer_arn = "${data.aws_lb.eq.arn}"
-  port              = "443"
-}
-
 data "aws_lb" "eq" {
   arn = "${var.aws_alb_arn}"
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -19,7 +19,7 @@ resource "aws_alb_target_group" "target_group" {
 
 resource "aws_alb_listener_rule" "listener_rule" {
   count        = "${var.dns_record_name == "" ? 1 : 0}"
-  listener_arn = "${data.aws_lb_listener.eq.id}"
+  listener_arn = "${var.aws_alb_listener_arn}"
   priority     = "${var.listener_rule_priority}"
 
   action {
@@ -41,7 +41,7 @@ resource "aws_alb_listener_rule" "listener_rule" {
 
 resource "aws_alb_listener_rule" "listener_rule_existing" {
   count        = "${var.dns_record_name == "" ? 0 : 1}"
-  listener_arn = "${data.aws_lb_listener.eq.id}"
+  listener_arn = "${var.aws_alb_listener_arn}"
   priority     = "${var.listener_rule_priority}"
 
   action {

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -22,6 +22,10 @@ variable "aws_alb_arn" {
   description = "The ARN of the ALB"
 }
 
+variable "aws_alb_listener_arn" {
+  description = "The ARN of the ALB"
+}
+
 variable "alb_listener_path_pattern" {
   description = "The path pattern to match to route to this service"
   default     = "/*"


### PR DESCRIPTION
 - This will prevent the race condition that we are currently experiencing when running terraform

Currently we are seeing the error `no listener exists for load balancer`