### PR TITLE
Added deregistration_delay of 20 seconds

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -1,8 +1,9 @@
 resource "aws_alb_target_group" "target_group" {
-  name     = "${var.env}-${var.service_name}"
-  port     = 80
-  protocol = "HTTP"
-  vpc_id   = "${var.vpc_id}"
+  name                 = "${var.env}-${var.service_name}"
+  port                 = 80
+  protocol             = "HTTP"
+  vpc_id               = "${var.vpc_id}"
+  deregistration_delay = 20
 
   health_check = {
     healthy_threshold   = 2

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -75,7 +75,7 @@ variable "container_port" {
 
 variable "container_memory_reservation" {
   description = "How much memory should be reserved for this container"
-  default = 128
+  default     = 128
 }
 
 variable "container_environment_variables" {


### PR DESCRIPTION
 - The default was 300 seconds, so this should speed up the removal of old containers

I observed that containers were hanging around for a while.
We have pretty quick response times from all of our containers so no need to hang onto them for the default of 300 seconds