### PR TITLE
Use no host on the internal ALB listener

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -26,6 +26,11 @@ variable "aws_alb_listener_arn" {
   description = "The ARN of the ALB"
 }
 
+variable "aws_alb_use_host_header" {
+  description = "Whether to add a host header rule to the ALB listener rules"
+  default     = true
+}
+
 variable "alb_listener_path_patterns" {
   description = "A list of path pattern to match to route to this service"
   type        = "list"


### PR DESCRIPTION
We can't use a Host header rule on the internal LB because of the WAF.

This change duplicates the listener and adds a condition for using the internal ALB.

Can test this using: https://github.com/ONSdigital/eq-terraform/pull/156