### PR TITLE
Add new output for target group ARN.

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -47,7 +47,7 @@ resource "aws_alb_listener_rule" "listener_rule" {
   condition = [
     {
       field  = "host-header"
-      values = ["${coalescelist(aws_route53_record.dns_record.*.name, list(var.dns_record_name))}"]
+      values = ["${var.listener_rule_host_header == "" ? coalescelist(aws_route53_record.dns_record.*.name, list(var.dns_record_name)) : var.listener_rule_host_header}"]
     },
     {
       field  = "path-pattern"

--- a/ecs.tf
+++ b/ecs.tf
@@ -30,6 +30,10 @@ resource "aws_alb_target_group" "target_group" {
   }
 }
 
+output "target_group_arn" {
+  value = "${aws_alb_target_group.target_group.arn}"
+}
+
 resource "aws_alb_listener_rule" "listener_rule" {
   count        = "${var.auth_issuer == "" && var.aws_alb_use_host_header ? length(var.alb_listener_path_patterns) : 0}"
   listener_arn = "${var.aws_alb_listener_arn}"

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -190,3 +190,8 @@ variable "auth_unauth_action" {
 variable "auth_scope" {
   default = "openid profile email"
 }
+
+variable "listener_rule_host_header" {
+  description = "A variable that can be set to override the host header"
+  default = ""
+}


### PR DESCRIPTION
## What is the context of this PR?
Author needed a way to add an additional listener rules to the load balancer but `eq-ecs-deploy` wasn't exposing the target group ARN from the module so it wasn't easy to add additional listener rules to point at the target group.

I originally went down the data source route, but adding an additional output to this module feels like a cleaner approach.